### PR TITLE
Fix signed installation token validation

### DIFF
--- a/apicommunication/transport.go
+++ b/apicommunication/transport.go
@@ -432,9 +432,11 @@ func ValidateInstallRequest(r *http.Request, st storage.Store) error {
 			if err != nil {
 				return nil, fmt.Errorf("reading public key from atlassian: %w", err)
 			}
-			return kidPKey, nil
+			// The JWT is signed with a private key using the RS256 algorithm.
+			// Reference: https://developer.atlassian.com/cloud/jira/platform/security-for-connect-apps/#signed-installation-callback-requests
+			return jwt.ParseRSAPublicKeyFromPEM(kidPKey)
 		}
-		return []byte{}, nil
+		return nil, nil
 	})
 	if err != nil {
 		if _, ok := err.(*jwt.ValidationError); ok {


### PR DESCRIPTION
Prevent the "key is of invalid type" by returning a parsed RSA-SHA256 public key for signed installation token validation.